### PR TITLE
config: update VDF STEP for 1s each 1 shot

### DIFF
--- a/miner/src/mock.rs
+++ b/miner/src/mock.rs
@@ -11,7 +11,7 @@ use crypto::dhash256;
 use primitives::bytes::Bytes;
 use ser::Stream;
 
-const STEP: u32 = 1024;
+const STEP: u32 = 233868;
 
 // consistent with verification/src/verify_block.rs
 fn h_g(block: &BlockTemplate, pubkey: &VrfPk) -> Integer {


### PR DESCRIPTION
configure VDF STEP so that each mock mining one shot takes 1 s.

result on AWS northeast t2.micro ubuntu 20.04 instance

```
ubuntu@ip-172-31-1-58:~$ ./pie19 
Challenge (seed) is: 0x1eeb30c7163271850b6d018e8282093ac6755a771da6267edf6c9b4fce9242ba

Evaluating VDF...
y: 0x30fc598543267634c1cc7d0076be84a5da2f93d69e40c58d256c8aea62ebcbab16d5a0f3a1abb5421503d7e87419938398fee8ef6cb48b9ab6ba6d92410898d4943292ef3929d131795dc92729bd33b1bcbc509f0abd2978f93796bc382bbb24515c6575dbb4d4e559a38942e39d9b2568c2c7c322d9ee0292cd098dd11a8855267c68aa1fe8bb3abe5a694b401f712837e86f4757e62cbc2fda37bb5fed681b4e1b104a033efacd5938888dcc9faa5dacb37b7779aa67af00d65fd33b4f4e8474f4fe294c39bc5efaafd1213b16a60b14a9f48c847543a805469965938a9746924371efcf4cf8c67ed8a6e3533b35595968289c7c0c4c1c0c03e5c9c50ed67
iterarions: 233868
pi_list_len: 18
Elapsed: 1.03 s

Verifying VDF...
Verified: true, elapsed: 131.70 ms
```